### PR TITLE
Correct MRA Rotation Value

### DIFF
--- a/_Arcade/Kyukyoku Tiger (Japan, 2P Co-Op).mra
+++ b/_Arcade/Kyukyoku Tiger (Japan, 2P Co-Op).mra
@@ -7,7 +7,7 @@
     <manufacturer>Toaplan / Taito Corporation</manufacturer>
     <players>2</players>
     <joystick>8-way</joystick>
-    <rotation>Vertical (CW)</rotation>
+    <rotation>Vertical (CCW)</rotation>
     <region>Japan</region>
     <platform>Twin Cobra Platform</platform>
     <category>Shoot'em up</category>

--- a/_Arcade/_alternatives/_Twin Cobra/Kyukyoku Tiger (Japan, 1P Set).mra
+++ b/_Arcade/_alternatives/_Twin Cobra/Kyukyoku Tiger (Japan, 1P Set).mra
@@ -7,7 +7,7 @@
     <manufacturer>Toaplan / Taito Corporation</manufacturer>
     <players>2</players>
     <joystick>8-way</joystick>
-    <rotation>Vertical (CW)</rotation>
+    <rotation>Vertical (CCW)</rotation>
     <region>Japan</region>
     <platform>Twin Cobra Platform</platform>
     <category>Shoot'em up</category>

--- a/_Arcade/_alternatives/_Twin Cobra/Twin Cobra (US).mra
+++ b/_Arcade/_alternatives/_Twin Cobra/Twin Cobra (US).mra
@@ -7,7 +7,7 @@
     <manufacturer>Toaplan / Taito America Corporation (Romstar License)</manufacturer>
     <players>2</players>
     <joystick>8-way</joystick>
-    <rotation>Vertical (CW)</rotation>
+    <rotation>Vertical (CCW)</rotation>
     <region>US</region>
     <platform>Twin Cobra Platform</platform>
     <category>Shoot'em up</category>

--- a/_Arcade/_alternatives/_Twin Cobra/Twin Cobra (World).mra
+++ b/_Arcade/_alternatives/_Twin Cobra/Twin Cobra (World).mra
@@ -7,7 +7,7 @@
     <manufacturer>Toaplan / Taito Corporation</manufacturer>
     <players>2</players>
     <joystick>8-way</joystick>
-    <rotation>Vertical (CW)</rotation>
+    <rotation>Vertical (CCW)</rotation>
     <region>World</region>
     <platform>Twin Cobra Platform</platform>
     <category>Shoot'em up</category>


### PR DESCRIPTION
The MRA Rotation flag is based on the direction the tube would be rotated in the cab, not the direction the video is rotated.

At least I think that is the reasoning :)